### PR TITLE
Add RTS to main code

### DIFF
--- a/tictactoe.asm
+++ b/tictactoe.asm
@@ -87,6 +87,7 @@ Space=" "
 	ldx	#26
 	jsr	VLine					;Draw vertical
 	
+	rts						;Main program should always return nicely to BASIC with rts
 	
 ;Make cursor placement sub
 GoXY:


### PR DESCRIPTION
The main function in the assembler program should return nicely to BASIC with an RTS
Otherwise the code in the first function will be called an extra time.